### PR TITLE
Better readability 

### DIFF
--- a/src/ArrayDataSet.php
+++ b/src/ArrayDataSet.php
@@ -22,12 +22,8 @@ class ArrayDataSet extends PHPUnit_Extensions_Database_DataSet_AbstractDataSet
      */
     public function __construct($files = null)
     {
-        if (is_array($files)) {
-            foreach ($files as $file) {
-                $this->addFile($file);
-            }
-        } else if ($files) {
-            $this->addFile($files);
+        foreach ((array)$files as $file) {
+            $this->addFile($file);
         }
     }
 


### PR DESCRIPTION
A simple typecast to array makes it possible to eliminate an entire if/else  if block  which renders better readability code. 
## Summary of Changes 
- type cast to array
